### PR TITLE
Added support of tokio-rustls and tokio-native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,15 @@ async = ["aerospike-core"]
 sync = ["aerospike-sync"]
 rt-tokio = ["aerospike-core/rt-tokio", "aerospike-macro/rt-tokio"]
 rt-async-std = ["aerospike-core/rt-async-std", "aerospike-macro/rt-async-std"]
+tokio-rustls = ["aerospike-core/tokio-rustls"]
+tokio-native-tls = ["aerospike-core/tokio-native-tls"]
 
 [[bench]]
 name = "client_server"
 harness = false
 
 [workspace]
-members = ["tools/benchmark", "aerospike-core", "aerospike-rt", "aerospike-sync", "aerospike-macro"]
+members = ["tools/benchmark", "aerospike-core", "aerospike-rt", "aerospike-sync", "aerospike-macro", "aerospike-tls"]
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -19,11 +19,15 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 aerospike-rt = {path = "../aerospike-rt"}
 futures = {version = "0.3.16" }
 async-trait = "0.1.51"
+aerospike-tls = { path = "../aerospike-tls", optional = true }
 
 [features]
 serialization = ["serde"]
 rt-tokio = ["aerospike-rt/rt-tokio"]
 rt-async-std = ["aerospike-rt/rt-async-std"]
+tls = []
+tokio-rustls = ["aerospike-tls/tokio-rustls", "rt-tokio", "tls"]
+tokio-native-tls = ["aerospike-tls/tokio-native-tls", "rt-tokio", "tls"]
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/aerospike-core/src/cluster/info_helper.rs
+++ b/aerospike-core/src/cluster/info_helper.rs
@@ -1,0 +1,256 @@
+use std::str::FromStr;
+
+use crate::errors::{ErrorKind, Result};
+
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServicesResponse<'a> {
+    pub peers_generation: u32,
+    pub port: u16,
+    pub nodes: Vec<NodeResponse<'a>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeResponse<'a> {
+    pub node_id: &'a str,
+    pub tls_name: Option<&'a str>,
+    pub endpoints: Vec<&'a str>,
+}
+
+pub fn parse_services_response<'a>(response: &'a str) -> Result<ServicesResponse<'a>> {
+    // peers-generation, port, [ list of [ NodeIDs/Names, TLSName(if defined), [ List of endpoints/IPaddresses ]]]
+
+    const COMMON : char = ',';
+    const OPEN_BRACE : char = '[';
+    const CLOSE_BRACE : char = ']';
+
+    fn remove_outer_bracers<'a>(input: &'a str) -> Result<&'a str> {
+        match (input.chars().next(), input.chars().nth(input.len() - 1)) {
+            (Some(OPEN_BRACE), Some(CLOSE_BRACE)) => Ok(&input[1..input.len()-1]),
+            _ => Result::Err(ErrorKind::BadResponse(format!("Missing outer bracers {input}")).into())
+        }
+    }
+
+    fn read_generation_and_port_and_nodes<'a>(input: &'a str) -> Result<(u32, u16, Vec<NodeResponse>)> {
+        
+        fn read_nodes<'a>(nodes: &'a str) -> Result<Vec<NodeResponse>> {
+            // [ list of [ NodeIDs/Names, TLSName(if defined), [ List of endpoints/IPaddresses ]]]
+            let mut result : Vec<NodeResponse> = vec![];
+    
+            fn read_node<'a>(node: &'a str) -> Result<NodeResponse> {
+                // [ NodeIDs/Names, TLSName(if defined), [ List of endpoints/IPaddresses ]]
+    
+                fn read_endpoints<'a>(endpoints: &'a str) -> Result<Vec<&'a str>> {
+                    // [ List of endpoints/IPaddresses ]
+    
+                    let endpoints = remove_outer_bracers(endpoints)?;
+                    
+                    Ok(endpoints.split(COMMON).collect::<Vec<_>>())
+                }
+    
+                let node = remove_outer_bracers(node)?;
+    
+                let first_common = node.find(COMMON)
+                    .ok_or(ErrorKind::BadResponse("Missing section after node id".to_string()))?;
+    
+                let node_id = node.get(0..first_common)
+                    .ok_or(ErrorKind::BadResponse("Missing node id".to_string()))?;
+    
+                let second_common = node[first_common+1..]
+                    .find(COMMON)
+                    .map(|x| x + first_common + 1)
+                    .ok_or(ErrorKind::BadResponse("Missing section after tls name".to_string()))?;
+    
+                let tls_name = node.get(first_common+1..second_common)
+                    .ok_or(ErrorKind::BadResponse("Missing tls name".to_string()))?;
+                let tls_name = if tls_name.is_empty() { None } else { Some(tls_name) };
+    
+                let endpoints_slice = node.get(second_common+1..)
+                    .ok_or(ErrorKind::BadResponse("Missing endpoints list".to_string()))?;
+                
+                let endpoints = read_endpoints(endpoints_slice)?;
+                
+                Ok(NodeResponse { node_id, tls_name, endpoints })
+            }
+    
+            let nodes = remove_outer_bracers(nodes)?;
+    
+            let mut opened_bracers : i32 = 0;
+            let mut first_opened_brace_pos : Option<usize> = None;
+            for (pos, ch) in nodes.char_indices() {
+                match ch {
+                    OPEN_BRACE => {
+                        if first_opened_brace_pos.is_none() {
+                            first_opened_brace_pos = Some(pos);
+                        }
+                        opened_bracers += 1;
+                        
+                    },
+                    CLOSE_BRACE => {
+                        opened_bracers -= 1;
+                        if opened_bracers < 0 {
+                            return Result::Err(ErrorKind::BadResponse("Malformed nodes list".to_string()).into());
+                        }
+    
+                        if opened_bracers == 0 {
+                            let Some(opened_brace_pos) = first_opened_brace_pos else {
+                                return Result::Err(ErrorKind::BadResponse("Wrong node list parser state".to_string()).into());
+                            };
+        
+                            let node_slice = nodes.get(opened_brace_pos..pos+1)
+                                .ok_or(ErrorKind::BadResponse("Invalid node slice in list".to_string()))?;
+        
+                            let node = read_node(node_slice)?;
+                            
+                            result.push(node);
+
+                            first_opened_brace_pos = None;
+                        }
+                    },
+                    _ => {},
+                }
+            }
+    
+            Ok(result)
+        }
+    
+        let first_common = input
+            .find(COMMON)
+            .ok_or(ErrorKind::BadResponse("Missing peers generation".to_string()))?;
+
+        let peers_generation_slice = input.get(0..first_common)
+            .ok_or(ErrorKind::BadResponse("Missing peers generation".to_string()))?;
+
+        let peers_generation = u32::from_str(peers_generation_slice)
+            .map_err(|_| ErrorKind::BadResponse("Peers generation should be u32".to_string()))?;
+
+        let second_common = input[first_common+1..]
+            .find(COMMON)
+            .map(|x| x + first_common + 1)
+            .ok_or(ErrorKind::BadResponse("Missing port".to_string()))?;
+
+        let port_slice = input.get(first_common+1..second_common)
+            .ok_or(ErrorKind::BadResponse("Missing port".to_string()))?;
+
+        let port = u16::from_str(port_slice)
+            .map_err(|_| ErrorKind::BadResponse("TCP port should be u16".to_string()))?;
+        
+        let nodes = input.get(second_common+1..)
+            .ok_or(ErrorKind::BadResponse("Missing node list".to_string()))?;
+
+        let nodes = read_nodes(nodes)?;
+
+        Ok((peers_generation, port, nodes))
+    }
+
+    let (peers_generation, port, nodes) = read_generation_and_port_and_nodes(response)?;
+
+    Ok(ServicesResponse {
+        peers_generation,
+        port,
+        nodes,
+    })
+}
+
+mod tests {
+    use crate::cluster::info_helper::{ServicesResponse, NodeResponse, parse_services_response};
+
+    #[test]
+    fn positive_cases() {
+        let responses = [
+            "9,3000,[[BB9040011AC4202,,[172.17.0.4]],[BB9050011AC4202,,[172.17.0.5]]]",
+            "9,3000,[[BB9060011AC4202,,[74.125.239.53]],[BB9070011AC4202,,[74.125.239.54]]]",
+            "10,4333,[[BB9060011AC4202,clusternode,[74.125.239.53]],[BB9070011AC4202,clusternode,[74.125.239.54]]]",
+            "10,4333,[[BB9040011AC4202,clusternode,[172.17.0.4,74.125.239.53]],[BB9050011AC4202,clusternode,[172.17.0.5,74.125.239.54]]]",
+        ];
+
+        let parsed_responses = [
+            ServicesResponse {
+                peers_generation: 9,
+                port: 3000,
+                nodes: vec![
+                    NodeResponse {
+                        node_id: "BB9040011AC4202",
+                        tls_name: None,
+                        endpoints: vec![
+                            "172.17.0.4",
+                        ]
+                    },
+                    NodeResponse {
+                        node_id: "BB9050011AC4202",
+                        tls_name: None,
+                        endpoints: vec![
+                            "172.17.0.5",
+                        ]
+                    },
+                ],
+            },
+            ServicesResponse {
+                peers_generation: 9,
+                port: 3000,
+                nodes: vec![
+                    NodeResponse {
+                        node_id: "BB9060011AC4202",
+                        tls_name: None,
+                        endpoints: vec![
+                            "74.125.239.53",
+                        ]
+                    },
+                    NodeResponse {
+                        node_id: "BB9070011AC4202",
+                        tls_name: None,
+                        endpoints: vec![
+                            "74.125.239.54",
+                        ]
+                    },
+                ],
+            },
+            ServicesResponse {
+                peers_generation: 10,
+                port: 4333,
+                nodes: vec![
+                    NodeResponse {
+                        node_id: "BB9060011AC4202",
+                        tls_name: Some("clusternode"),
+                        endpoints: vec![
+                            "74.125.239.53",
+                        ]
+                    },
+                    NodeResponse {
+                        node_id: "BB9070011AC4202",
+                        tls_name: Some("clusternode"),
+                        endpoints: vec![
+                            "74.125.239.54",
+                        ]
+                    },
+                ],
+            },
+            ServicesResponse {
+                peers_generation: 10,
+                port: 4333,
+                nodes: vec![
+                    NodeResponse {
+                        node_id: "BB9040011AC4202",
+                        tls_name: Some("clusternode"),
+                        endpoints: vec![
+                            "172.17.0.4",
+                            "74.125.239.53",
+                        ]
+                    },
+                    NodeResponse {
+                        node_id: "BB9050011AC4202",
+                        tls_name: Some("clusternode"),
+                        endpoints: vec![
+                            "172.17.0.5",
+                            "74.125.239.54",
+                        ]
+                    },
+                ],
+            },
+        ];
+
+        for (parsed, response) in parsed_responses.iter().zip(responses.iter()) {
+            assert_eq!(parsed, &parse_services_response(response).unwrap());
+        }
+    }
+}

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -17,6 +17,7 @@ pub mod node;
 pub mod node_validator;
 pub mod partition;
 pub mod partition_tokenizer;
+mod info_helper;
 
 use aerospike_rt::time::{Duration, Instant};
 use std::collections::HashMap;

--- a/aerospike-core/src/lib.rs
+++ b/aerospike-core/src/lib.rs
@@ -147,6 +147,8 @@ extern crate lazy_static;
 extern crate log;
 extern crate pwhash;
 extern crate rand;
+#[cfg(feature = "tls")]
+pub extern crate aerospike_tls;
 
 pub use batch::BatchRead;
 pub use bin::{Bin, Bins};
@@ -170,6 +172,8 @@ pub use result_code::ResultCode;
 pub use task::{IndexTask, RegisterTask, Task};
 pub use user::User;
 pub use value::{FloatValue, Value};
+#[cfg(feature = "tls")]
+pub use aerospike_tls::{self as tls, *};
 
 #[macro_use]
 pub mod errors;

--- a/aerospike-core/src/net/connection_pool.rs
+++ b/aerospike-core/src/net/connection_pool.rs
@@ -85,7 +85,7 @@ impl Queue {
 
             let conn = aerospike_rt::timeout(
                 Duration::from_secs(5),
-                Connection::new(&self.0.host.address(), &self.0.policy),
+                Connection::new(&self.0.host, &self.0.policy),
             )
             .await;
 

--- a/aerospike-core/src/net/connection_stream/async_std.rs
+++ b/aerospike-core/src/net/connection_stream/async_std.rs
@@ -1,0 +1,53 @@
+use std::{pin::Pin, task::{Poll, Context}};
+use aerospike_rt::net::TcpStream;
+use futures::{AsyncRead, AsyncWrite};
+use aerospike_rt::async_std::net::Shutdown;
+
+#[derive(Debug)]
+pub enum ConnectionStream {
+    Tcp(TcpStream),
+}
+
+impl ConnectionStream {
+    pub fn shutdown(&mut self, how: Shutdown) -> Result<(), std::io::Error> {
+        match self {
+            Self::Tcp(stream) => stream.shutdown(how)
+        }
+    }
+}
+
+impl AsyncRead for ConnectionStream {
+    fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Self::Tcp(stream) => Pin::new(stream).poll_read(cx, buf)
+        }
+    }
+}
+
+impl AsyncWrite for ConnectionStream {
+    fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            match self.get_mut() {
+                Self::Tcp(stream) => Pin::new(stream).poll_write(cx, buf)
+            }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Tcp(stream) => Pin::new(stream).poll_flush(cx)
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            Self::Tcp(stream) => Pin::new(stream).poll_close(cx)
+        }
+    }
+}

--- a/aerospike-core/src/net/connection_stream/mod.rs
+++ b/aerospike-core/src/net/connection_stream/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(all(any(not(feature = "rt-async-std")), feature = "rt-tokio"))]
+mod tokio;
+
+#[cfg(all(any(feature = "rt-async-std"), not(feature = "rt-tokio")))]
+mod async_std;
+
+#[cfg(all(any(not(feature = "rt-async-std")), feature = "rt-tokio"))]
+pub use self::tokio::ConnectionStream;
+
+#[cfg(all(any(feature = "rt-async-std"), not(feature = "rt-tokio")))]
+pub use self::async_std::ConnectionStream;

--- a/aerospike-core/src/net/connection_stream/tokio.rs
+++ b/aerospike-core/src/net/connection_stream/tokio.rs
@@ -1,0 +1,60 @@
+use std::{pin::Pin, task::{Poll, Context}};
+use aerospike_rt::net::TcpStream;
+use aerospike_rt::io::{AsyncRead, AsyncWrite};
+
+#[cfg(feature = "tls")]
+use aerospike_tls::TlsStream;
+
+#[derive(Debug)]
+pub enum ConnectionStream {
+    Tcp(TcpStream),
+    #[cfg(feature = "tls")]
+    Tls(TlsStream),
+}
+
+impl AsyncRead for ConnectionStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut aerospike_rt::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            #[cfg(feature = "tls")]
+            Self::Tls(stream) => Pin::new(stream).poll_read(cx, buf),
+            Self::Tcp(stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for ConnectionStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        match self.get_mut() {
+            #[cfg(feature = "tls")]
+            Self::Tls(stream) => Pin::new(stream).poll_write(cx, buf),
+            Self::Tcp(stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        match self.get_mut() {
+            #[cfg(feature = "tls")]
+            Self::Tls(stream) => Pin::new(stream).poll_flush(cx),
+            Self::Tcp(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        match self.get_mut() {
+            #[cfg(feature = "tls")]
+            Self::Tls(stream) => Pin::new(stream).poll_shutdown(cx),
+            Self::Tcp(stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}

--- a/aerospike-core/src/net/mod.rs
+++ b/aerospike-core/src/net/mod.rs
@@ -21,5 +21,6 @@ pub use self::host::ToHosts;
 
 mod connection;
 mod connection_pool;
+mod connection_stream;
 pub mod host;
 mod parser;

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 
 use crate::commands::admin_command::AdminCommand;
 use crate::errors::Result;
+#[cfg(feature = "tls")]
+use crate::policy::TlsPolicy;
 
 /// `ClientPolicy` encapsulates parameters for client policy command.
 #[derive(Debug, Clone)]
@@ -83,6 +85,9 @@ pub struct ClientPolicy {
     /// to join the client's view of the cluster. Should only be set when connecting to servers
     /// that support the "cluster-name" info command.
     pub cluster_name: Option<String>,
+
+    #[cfg(feature = "tls")]
+    pub tls_policy: Option<TlsPolicy>,
 }
 
 impl Default for ClientPolicy {
@@ -100,6 +105,8 @@ impl Default for ClientPolicy {
             thread_pool_size: 128,
             cluster_name: None,
             buffer_reclaim_threshold: 65536,
+            #[cfg(feature = "tls")]
+            tls_policy: None,
         }
     }
 }

--- a/aerospike-core/src/policy/mod.rs
+++ b/aerospike-core/src/policy/mod.rs
@@ -29,6 +29,8 @@ mod query_policy;
 mod read_policy;
 mod record_exists_action;
 mod scan_policy;
+#[cfg(feature = "tls")]
+mod tls_policy;
 mod write_policy;
 
 pub use self::admin_policy::AdminPolicy;
@@ -44,6 +46,8 @@ pub use self::query_policy::QueryPolicy;
 pub use self::read_policy::ReadPolicy;
 pub use self::record_exists_action::RecordExistsAction;
 pub use self::scan_policy::ScanPolicy;
+#[cfg(feature = "tls")]
+pub use self::tls_policy::TlsPolicy;
 pub use self::write_policy::WritePolicy;
 
 use crate::expressions::FilterExpression;

--- a/aerospike-core/src/policy/tls_policy.rs
+++ b/aerospike-core/src/policy/tls_policy.rs
@@ -1,0 +1,12 @@
+use aerospike_tls::TlsConnector;
+
+#[derive(Debug, Clone)]
+pub struct TlsPolicy {
+    pub tls_connector: TlsConnector,
+}
+
+impl TlsPolicy {
+    pub fn new(tls_connector: TlsConnector) -> Self {
+        Self { tls_connector, }
+    }
+}

--- a/aerospike-tls/Cargo.toml
+++ b/aerospike-tls/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "aerospike-tls"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures = { version = "0.3.16" }
+aerospike-rt = { path = "../aerospike-rt" }
+tokio-rustls = { version = "0.23.4", optional = true }
+webpki = { version = "0.22.0", optional = true }
+tokio-native-tls = { version = "0.3.0", optional = true }
+
+[features]
+default = ["tokio-rustls"]
+tokio-rustls = ["dep:tokio-rustls", "dep:webpki", "aerospike-rt/rt-tokio"]
+tokio-native-tls = ["dep:tokio-native-tls", "aerospike-rt/rt-tokio"]

--- a/aerospike-tls/src/lib.rs
+++ b/aerospike-tls/src/lib.rs
@@ -1,0 +1,19 @@
+#[cfg(not(any(feature = "tokio-rustls", feature = "tokio-native-tls")))]
+compile_error!("Please select a tls implementation from ['tokio-rustls', 'tokio-native-tls']");
+
+#[cfg(feature = "tokio-rustls")]
+extern crate tokio_rustls;
+
+#[cfg(feature = "tokio-native-tls")]
+extern crate tokio_native_tls;
+
+mod tls_connector;
+mod tls_stream;
+
+pub use tls_connector::{TlsConnectError, TlsConnector};
+pub use tls_stream::TlsStream;
+#[cfg(feature = "tokio-rustls")]
+pub use tokio_rustls::*;
+
+#[cfg(feature = "tokio-native-tls")]
+pub use tokio_native_tls::*;

--- a/aerospike-tls/src/tls_connector.rs
+++ b/aerospike-tls/src/tls_connector.rs
@@ -1,0 +1,68 @@
+use crate::tls_stream::TlsStream;
+use aerospike_rt::net::TcpStream;
+use std::fmt::Debug;
+#[cfg(feature = "tokio-rustls")]
+use tokio_rustls::rustls::ServerName;
+
+#[derive(Clone)]
+pub enum TlsConnector {
+    #[cfg(feature = "tokio-rustls")]
+    Rustls(tokio_rustls::TlsConnector),
+    #[cfg(feature = "tokio-native-tls")]
+    NativeTls(tokio_native_tls::TlsConnector),
+}
+
+impl Debug for TlsConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(_) => f.debug_tuple("Rustls").finish(),
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(_) => f.debug_tuple("NativeTls").finish(),
+        }
+    }
+}
+
+pub enum TlsConnectError {
+    IO(std::io::Error),
+    InvalidDnsName,
+    #[cfg(feature = "tokio-native-tls")]
+    NativeTlsError(tokio_native_tls::native_tls::Error),
+}
+
+impl TlsConnector {
+    #[cfg(feature = "tokio-rustls")]
+    pub fn new_rustls(connector: tokio_rustls::TlsConnector) -> Self {
+        Self::Rustls(connector)
+    }
+
+    #[cfg(feature = "tokio-native-tls")]
+    pub fn new_native_tls(connector: tokio_native_tls::TlsConnector) -> Self {
+        Self::NativeTls(connector)
+    }
+
+    pub async fn connect(
+        &self,
+        domain: &str,
+        stream: TcpStream,
+    ) -> Result<TlsStream, TlsConnectError> {
+        match self {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(connector) => {
+                let domain =
+                    ServerName::try_from(domain).map_err(|_| TlsConnectError::InvalidDnsName)?;
+                connector
+                    .connect(domain, stream)
+                    .await
+                    .map_err(|err| TlsConnectError::IO(err))
+                    .map(|stream| TlsStream::Rustls(stream))
+            }
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(connector) => connector
+                .connect(domain, stream)
+                .await
+                .map_err(|err| TlsConnectError::NativeTlsError(err))
+                .map(|stream| TlsStream::NativeTls(stream)),
+        }
+    }
+}

--- a/aerospike-tls/src/tls_stream.rs
+++ b/aerospike-tls/src/tls_stream.rs
@@ -1,0 +1,73 @@
+use std::{fmt::Debug, pin::Pin};
+
+use aerospike_rt::{io::AsyncRead, io::AsyncWrite, net::TcpStream};
+use std::task::{Context, Poll};
+
+pub enum TlsStream {
+    #[cfg(feature = "tokio-rustls")]
+    Rustls(tokio_rustls::client::TlsStream<TcpStream>),
+    #[cfg(feature = "tokio-native-tls")]
+    NativeTls(tokio_native_tls::TlsStream<TcpStream>),
+}
+
+impl Debug for TlsStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(_) => f.debug_tuple("Rustls").finish(),
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(_) => f.debug_tuple("NativeTls").finish(),
+        }
+    }
+}
+
+impl AsyncRead for TlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut aerospike_rt::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(stream) => Pin::new(stream).poll_read(cx, buf),
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for TlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        match self.get_mut() {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(stream) => Pin::new(stream).poll_write(cx, buf),
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        match self.get_mut() {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(stream) => Pin::new(stream).poll_flush(cx),
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        match self.get_mut() {
+            #[cfg(feature = "tokio-rustls")]
+            Self::Rustls(stream) => Pin::new(stream).poll_shutdown(cx),
+            #[cfg(feature = "tokio-native-tls")]
+            Self::NativeTls(stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}


### PR DESCRIPTION
Hi

This pull request contains support of TLS with `tokio-rustls` and `tokio-native-tls` crates. I tested it with the CE version of aerospike from official docker image.  CE version doesn't support TLS, but I used `openssl` for wrapping TCP socket into TLS:
```
socat openssl-listen:4000,reuseaddr,cert=example.server.pem,cafile=example.ca.crt,verify=0,openssl-min-proto-version=TLS1.2,fork,reuseaddr TCP4:localhost:3000
```
This setup working with `aql` and version from that pull request.